### PR TITLE
more flexible webhook handling, added npm capability

### DIFF
--- a/routes/projects.js
+++ b/routes/projects.js
@@ -18,6 +18,7 @@ router.get('/:project_id/enable', function(req, res, next) {
     });
     fs.readFile(config.deploy.sshPublicKey, function(err, data) {
         if (err) {
+            console.log(err);
             return res.redirect('/');
         }
         var key = data.toString();
@@ -25,15 +26,17 @@ router.get('/:project_id/enable', function(req, res, next) {
             id: projectId,
             title: "GitLab Pages",
             key: key
-        }
+        };
         gitlab.projects.deploy_keys.addKey(projectId, params, function(results) {
             var webhookUrl = config.server.publicUrl+"/webhooks/pages.json";
             gitlab.projects.hooks.list(projectId, function(hooks) {
                 if (_.findIndex(hooks, { 'url': webhookUrl }) === -1) {
+                    console.log('adding hook');
                     gitlab.projects.hooks.add(projectId, webhookUrl, function(results) {
                         res.redirect('/');
                     });
                 } else {
+                    console.log('hook already added');
                     res.redirect('/');
                 }
             });

--- a/routes/webhooks.js
+++ b/routes/webhooks.js
@@ -82,6 +82,7 @@ router.post('/pages.json', function(req, res, next) {
                     } else if (fs.existsSync(npm_path)) {
                         var npmConfig = require(npm_path);
                         npmConfig.siteRoot = siteRoot;
+                        npmConfig.vDir = '/pages/'+projectNamespace+'/'+projectName;
                         fs.writeFile(npm_path, JSON.stringify(npmConfig));
                         cmd = "(cd " + repoPath + " && npm install && npm run-script pages)";
                         console.log('Building site with npm run-script pages');

--- a/routes/webhooks.js
+++ b/routes/webhooks.js
@@ -21,10 +21,12 @@ router.post('/pages.json', function(req, res, next) {
     var afterCommit = payload.after;
     var ref = payload.ref;
 
+    console.log('caught webhook: ======');
+    console.log(payload);
+
     // Check if this is the deploy branch
     var deployRef = "refs/heads/"+config.deploy.deployBranch;
     if (ref !== deployRef) {
-        // console.log(ref, deployRef);
         return res.end();
     }
 
@@ -40,6 +42,7 @@ router.post('/pages.json', function(req, res, next) {
             }
         }
     };
+
     var repository = payload.repository;
     var url = repository.url;
     url_path = urllib.parse(url)['path'] // should be like '/Chuck.Sakoda/webhooks-test-repo.git'
@@ -59,32 +62,37 @@ router.post('/pages.json', function(req, res, next) {
             })
             .done(function() {
                 // Move from workingDir to pages dir
-                var finalRepoPath = path.resolve(config.deploy.publicPagesDir, projectNamespace, projectName);
+                var siteRoot =
+                    path.resolve(config.deploy.publicPagesDir, projectNamespace, projectName);
+
                 // Delete workingDir
-                rmdir(finalRepoPath, function() {
-		    mkdocs_path = path.resolve(repoPath, 'mkdocs.yml');
-		    fs.exists(mkdocs_path, function (exists) {
-			if (exists) {
-			    mkdocs = YAML.load(mkdocs_path);
-			    mkdocs['site_dir'] = finalRepoPath;
-			    fs.writeFile(mkdocs_path, YAML.stringify(mkdocs, 4));
-			    var cmd = "(cd "+repoPath+" && mkdocs build --clean)";
-			    console.log('Building site with mkdocs') 
-			} else {
-			    // jekyll build --safe --source .tmp/Glavin001/gitlab-pages-example/ --destination pages/Glavin001/gitlab-pages-example
-			    var cmd = "jekyll build --safe --source \""+repoPath+"\" --destination \""+finalRepoPath+"\"";
-			}
-			exec(cmd, function (error, stdout, stderr) {
-                            // output is in stdout
-                            console.log('Done deploying '+projectNamespace+'/'+projectName);
-			});
-		    });
-                    // mv(repoPath, finalRepoPath, {
-                    //     mkdirp: true,
-                    //     clobber: true
-                    // }, function(err) {
-                    //     console.log('Done deploying '+projectNamespace+'/'+projectName);
-                    // });
+                rmdir(siteRoot, function() {
+                    mkdocs_path = path.resolve(repoPath, 'mkdocs.yml');
+                    npm_path = path.resolve(repoPath, 'package.json');
+                    var cmd =
+                      "jekyll build --safe --source \"" +
+                      repoPath + "\" --destination \"" +
+                      siteRoot + "\"";
+                    if (fs.existsSync(mkdocs_path)) {
+                        var mkdocs = YAML.load(mkdocs_path);
+                        mkdocs.site_dir = siteRoot;
+                        fs.writeFile(mkdocs_path, YAML.stringify(mkdocs, 4));
+                        cmd = "(cd "+repoPath+" && mkdocs build --clean)";
+                        console.log('Building site with mkdocs');
+                    } else if (fs.existsSync(npm_path)) {
+                        var npmConfig = require(npm_path);
+                        npmConfig.siteRoot = siteRoot;
+                        fs.writeFile(npm_path, JSON.stringify(npmConfig));
+                        cmd = "(cd " + repoPath + " && npm install && npm run-script pages)";
+                        console.log('Building site with npm run-script pages');
+                    } else {
+                        console.log('Building site with jeckyll');
+                    }
+
+                    exec(cmd, function (error, stdout, stderr) {
+                        // output is in stdout
+                        console.log('Done deploying '+projectNamespace+'/'+projectName);
+                    });
                 });
             });
         }


### PR DESCRIPTION
- made fs.exists calls synchronous so we don't have inception-style repo-type checks.
- added npm project builds.
  
  npm projects must have 3 items defined in their _package.json_:

``` json
  // must have scripts.pages defined. webhook runs *npm run-script pages* to build the site
  "scripts": {
    "pages": "grunt build:dev"
  },
  // siteRoot will be replaced with the gl-pages static content root to build to. 
  // Use this in your project's build config as the build output directory
  "siteRoot": "dist/docs",
  // Actual URL the web site will be rooted in for use in configuring asset paths.
  "vDir": "/pages/x/ui"
```
