### PR TITLE
remove redundant /pages path segment

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,13 +42,11 @@ app.use('/projects', projects);
 app.use('/webhooks', webhooks);
 
 // Pages
-app.use('/pages', express.static(config.deploy.publicPagesDir));
-app.use('/pages/:namespace/:project/*', function(req, res, next) {
-    // Serve directory indexes for public/ftp folder (with icons)
-    var p = req.originalUrl.replace(/^\/pages\//, '');
-    var dir = path.join(config.deploy.publicPagesDir, p);
-    var index = serveIndex(dir, {'icons': true})
-    index(req, res, next);
+app.use('/:namespace/:project', function(req, res, next) {
+  var dir =
+    path.join(config.deploy.publicPagesDir, req.params.namespace, req.params.project);
+  var serveStaticContent = express.static(dir);
+  return serveStaticContent(req, res, next);
 });
 
 // catch 404 and forward to error handler

--- a/routes/webhooks.js
+++ b/routes/webhooks.js
@@ -14,10 +14,8 @@ var YAML = require('yamljs');
 /* POST  */
 router.post('/pages.json', function(req, res, next) {
     var payload = req.body;
-    // console.log(payload);
     var userId = payload.user_id;
     var projectId = payload.project_id;
-    // console.log('pages', userId, projectId);
     var afterCommit = payload.after;
     var ref = payload.ref;
 
@@ -45,7 +43,7 @@ router.post('/pages.json', function(req, res, next) {
 
     var repository = payload.repository;
     var url = repository.url;
-    url_path = urllib.parse(url)['path'] // should be like '/Chuck.Sakoda/webhooks-test-repo.git'
+    url_path = urllib.parse(url).path; // should be like '/Chuck.Sakoda/webhooks-test-repo.git'
     var projectNamespace = url_path.split('/')[1];
     var projectName = url_path.split('/')[2]; // ends with .git
     projectName = projectName.substring(0, projectName.length - 4);
@@ -82,7 +80,7 @@ router.post('/pages.json', function(req, res, next) {
                     } else if (fs.existsSync(npm_path)) {
                         var npmConfig = require(npm_path);
                         npmConfig.siteRoot = siteRoot;
-                        npmConfig.vDir = '/pages/'+projectNamespace+'/'+projectName;
+                        npmConfig.vDir = '/' + projectNamespace + '/' + projectName;
                         fs.writeFile(npm_path, JSON.stringify(npmConfig));
                         cmd = "(cd " + repoPath + " && npm install && npm run-script pages)";
                         console.log('Building site with npm run-script pages');

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -16,7 +16,7 @@
                 <a href="/projects/{{id}}/enable" type="button" class="btn btn-primary pull-right">Enable</a>
             {{/if}}
             <h4 class="list-group-item-heading">
-                <a href="/pages/{{path_with_namespace}}" target="_blank">{{name}} ({{name_with_namespace}})</a>
+                <a href="/{{path_with_namespace}}" target="_blank">{{name}} ({{name_with_namespace}})</a>
             </h4>
             <p class="list-group-item-text">{{description}}</p>
         </div>


### PR DESCRIPTION
effects of this change:
- all pages now look like http://pages.ims.io/:namespace/:project. ie. http://pages.ims.io/x/ui (instead of /pages/:namespace/:project).
- can no longer browse the site roots with ftp (don't really care do we?).
