### PR TITLE
fix deployBranch template in default_config

### DIFF
--- a/bin/config_and_run.sh
+++ b/bin/config_and_run.sh
@@ -4,7 +4,10 @@
 py_replace() {
     python -c "
 f = open('/GitLab-Pages/_config.js')
-txt = f.read().replace('$1: null','$1: \"$2\"')
+if $# == 3:
+    txt = f.read().replace('$1: \"$3\"','$1: \"$2\"')
+else:
+    txt = f.read().replace('$1: null','$1: \"$2\"')
 f.close()
 f = open('/GitLab-Pages/_config.js', 'w')
 f.write(txt)
@@ -15,7 +18,7 @@ cp /GitLab-Pages/default_config.js /GitLab-Pages/_config.js
 
 py_replace url $GITLAB_URL
 py_replace publicUrl $EXT_URL
-py_replace deployBranch $REF_TO_DEPLOY
+py_replace deployBranch $REF_TO_DEPLOY gl-pages
 
 if [ ! -f keys/id_rsa ]; then
     ssh-keygen -t rsa -f "keys/id_rsa"

--- a/default_config.js
+++ b/default_config.js
@@ -19,7 +19,7 @@ module.exports = {
         /**
         Specific branch that will be deployed when pushed
         */
-        deployBranch: "gl-pages",
+        deployBranch: null,
         /**
         Final, public directory of GitLab Pages.
         Jekyll builds will go here, or other static files.

--- a/default_config.js
+++ b/default_config.js
@@ -19,7 +19,7 @@ module.exports = {
         /**
         Specific branch that will be deployed when pushed
         */
-        deployBranch: null,
+        deployBranch: "gl-pages",
         /**
         Final, public directory of GitLab Pages.
         Jekyll builds will go here, or other static files.


### PR DESCRIPTION
Derp. need the default_config template property for `deployBranch` to match the regex expected in config_and_run.sh.
